### PR TITLE
Update package.lock for release 3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "get-site-urls",
-	"version": "3.0.0-alpha.1",
+	"version": "3.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "get-site-urls",
-			"version": "3.0.0-alpha.1",
+			"version": "3.0.0",
 			"license": "MIT",
 			"dependencies": {
 				"got": "^12.1.0",


### PR DESCRIPTION
Updates the `package.lock` that seems to still list `3.0.0-alpha.1` version.